### PR TITLE
Add support for includes

### DIFF
--- a/.changeset/dry-singers-flash.md
+++ b/.changeset/dry-singers-flash.md
@@ -1,0 +1,5 @@
+---
+'vitepress-plugin-shiki-twoslash': patch
+---
+
+Added support for Shiki Twoslash's [includes system](https://github.com/shikijs/twoslash/blob/main/site/components/docs/DRY.mdx)

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -120,6 +120,10 @@ export default withTwoslash(
                 text: 'Logging',
                 link: '/api/logging',
               },
+              {
+                text: 'Includes',
+                link: '/api/includes',
+              },
             ],
           },
           {

--- a/docs/api/includes.md
+++ b/docs/api/includes.md
@@ -1,0 +1,137 @@
+---
+description: 'Include hidden TypeScript parts in your code examples.'
+title: 'Includes'
+---
+
+# Includes
+
+As your documentation grows, you may need a way of re-using code blocks to prevent code duplication. Shiki Twoslash provides a simple includes system.
+
+## Defining a re-usable block
+
+Re-usable code blocks are defined by the `twoslash` language, followed by the `include` keyword and the reference name of your choice.
+
+````md
+```twoslash include myBlock
+type SomeString = string
+```
+````
+
+### Incremental steps
+
+Shiki Twoslash also provide the ability to define incremental steps through the definition of re-usable blocks. This means whenever a new step is delimited down the code, it will also include previous steps. These are **not groups**.
+
+- Incremental steps are delimited by `// - [name of the step]`
+- They are are named **at the end** of the actual code
+
+````md
+```twoslash include myBlockWithSteps
+type SomeString = string
+// - base
+type SomeUser = { name: string; mail?: SomeUserMail }
+type SomeUserMail = { content: string; verified: boolean }
+// - afterUserDefinitions
+type SomeGroup = { name: string; members: SomeUser[] }
+// - afterGroupDefinitions
+```
+````
+
+## Including a whole block
+
+To include a re-usable block, add `// @include: [block name]` in your code block.
+
+```twoslash include myBlock
+type SomeString = string
+```
+
+::: code-group
+
+```ts twoslash [output]
+// @include: myBlock
+const a: SomeString = 'string'
+```
+
+````md [markdown]
+```twoslash include myBlock
+type SomeString = string
+```
+
+```ts twoslash
+// @include: myBlock
+const a: SomeString = 'string'
+```
+````
+
+:::
+
+## Including a block step
+
+To include a re-usable block at a specific step, add `// @include: [block name]-[step name]` in your code block.
+
+```twoslash include myBlockWithSteps
+type SomeString = string
+// - base
+type SomeUser = { name: string; mail?: SomeUserMail }
+type SomeUserMail = { content: string; verified: boolean }
+// - afterUserDefinitions
+type SomeGroup = { name: string; members: SomeUser[] }
+// - afterGroupDefinitions
+```
+
+::: code-group
+
+```ts twoslash [output]
+// @include: myBlockWithSteps-afterUserDefinitions
+const mail: SomeUserMail = { content: 'some-email', verified: true }
+```
+
+````md [markdown]
+```twoslash include myBlockWithSteps
+type SomeString = string
+// - base
+type SomeUser = { name: string; mail?: SomeUserMail }
+type SomeUserMail = { content: string; verified: boolean }
+// - afterUserDefinitions
+type SomeGroup = { name: string; members: SomeUser[] }
+// - afterGroupDefinitions
+```
+
+```ts twoslash
+// @include: myBlockWithSteps-afterUserDefinitions
+const mail: SomeUserMail = { content: 'some-email', verified: true }
+```
+````
+
+:::
+
+## Hiding re-used code
+
+Re-using a lot of TypeScript code can easily bloat your documentation and obstruct the main point of your code block. You can hide re-used code to keep your code blocks clean and concise by [cutting](/api/cutting) right after the `@include` statement.
+
+::: code-group
+
+```ts twoslash [output]
+// @include: myBlockWithSteps-afterUserDefinitions
+// ---cut---
+const mail: SomeUserMail = { content: 'some-email', verified: true }
+```
+
+````md [markdown]
+```twoslash include myBlockWithSteps
+type SomeString = string
+// - base
+type SomeUser = { name: string; mail?: SomeUserMail }
+type SomeUserMail = { content: string; verified: boolean }
+// - afterUserDefinitions
+type SomeGroup = { name: string; members: SomeUser[] }
+// - afterGroupDefinitions
+```
+
+```ts twoslash
+// @include: myBlockWithSteps-afterUserDefinitions
+// ---cut---
+const mail: SomeUserMail = { content: 'some-email', verified: true }
+```
+````
+
+:::

--- a/docs/api/includes.md
+++ b/docs/api/includes.md
@@ -22,7 +22,7 @@ type SomeString = string
 Shiki Twoslash also provide the ability to define incremental steps through the definition of re-usable blocks. This means whenever a new step is delimited down the code, it will also include previous steps. These are **not groups**.
 
 - Incremental steps are delimited by `// - [name of the step]`
-- They are are named **at the end** of the actual code
+- They are named **at the end** of the actual code
 
 ````md
 ```twoslash include myBlockWithSteps

--- a/docs/api/includes.md
+++ b/docs/api/includes.md
@@ -1,5 +1,5 @@
 ---
-description: 'Include hidden TypeScript parts in your code examples.'
+description: 'Include re-usable TypeScript blocks in your code examples.'
 title: 'Includes'
 ---
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,7 +34,7 @@ export async function withTwoslash(config: UserConfig<DefaultTheme.Config>) {
   config.markdown.config = (md) => {
     const h = md.options.highlight
     md.options.highlight = (code, lang, attrs) => {
-      if (/twoslash/.test(attrs))
+      if (lang === 'twoslash' || /twoslash/.test(attrs))
         return transformAttributesToHTML(
           code.replace(/\r?\n$/, ''), // strip trailing newline fed during code block parsing
           [lang, attrs].join(' '),

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,8 +34,9 @@ export async function withTwoslash(config: UserConfig<DefaultTheme.Config>) {
   config.markdown.config = (md) => {
     const h = md.options.highlight
     md.options.highlight = (code, lang, attrs) => {
-      if (lang === 'twoslash' || /twoslash/.test(attrs))
-        return transformAttributesToHTML(
+      const isReusableBlock = lang === 'twoslash'
+      if (isReusableBlock || /twoslash/.test(attrs)) {
+        const output = transformAttributesToHTML(
           code.replace(/\r?\n$/, ''), // strip trailing newline fed during code block parsing
           [lang, attrs].join(' '),
           highlighters,
@@ -46,6 +47,9 @@ export async function withTwoslash(config: UserConfig<DefaultTheme.Config>) {
               : twoslashConfig.addTryButton,
           },
         )
+
+        return isReusableBlock ? '<pre />' : output
+      }
 
       return h!(code, lang, attrs)
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -63,7 +63,10 @@ pre.shiki .language-id {
   display: none;
 }
 
-/** Hide twoslash includes' definition code-blocks. */
+/*
+ * Hide twoslash's re-usable code-blocks.
+ * @TODO: we should find a way of getting rid of the whole codeblock markup (#10)
+ */
 .language-twoslash {
   display: none;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,6 @@
 /* Start of Shiki Twoslash CSS:
 
-Code blocks structurally look like: 
+Code blocks structurally look like:
 
 <pre class='shiki lsp twoslash [theme-name]'>
   <div class='language-id'>[lang-id]</div>
@@ -8,7 +8,7 @@ Code blocks structurally look like:
       <code>[the code as a series of spans]</code>
       <a href='playground...'>Try</a> (optional)
     </div>
-  </pre> 
+  </pre>
 */
 
 :root {
@@ -60,6 +60,11 @@ pre.shiki.twoslash code {
 
 /* Don't show the language identifiers */
 pre.shiki .language-id {
+  display: none;
+}
+
+/** Hide twoslash includes' definition code-blocks. */
+.language-twoslash {
   display: none;
 }
 


### PR DESCRIPTION
## Description

Hey, thank you for your plugin, it saved me quite some time. Shiki Twoslash supports [includes](https://github.com/shikijs/twoslash/blob/main/site/components/docs/DRY.mdx), but I could not get them working out-of-the-box using the plugin, or find any information in the docs. I came up with this simple PR to add support for includes and some documentation.

Please let me know what you think :)

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/vitepress-plugin-shiki-twoslash/blob/main/.github/CONTRIBUTING.md) (but still not sure about whether I'm supposed to run changeset)
- [x] I added documentation related to the changes made.
